### PR TITLE
fix: logging instance

### DIFF
--- a/custom_components/basestation/switch.py
+++ b/custom_components/basestation/switch.py
@@ -1,15 +1,19 @@
 """The basestation switch."""
 
-from bleak import BleakClient
-from homeassistant.components.switch import SwitchEntity
-from homeassistant.components import bluetooth
 import asyncio
+import logging
+
+from bleak import BleakClient
+from homeassistant.components import bluetooth
+from homeassistant.components.switch import SwitchEntity
 
 from .const import (
     PWR_CHARACTERISTIC,
     PWR_ON,
     PWR_STANDBY,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):


### PR DESCRIPTION
`TimeoutError`s are currently still logged, just with a huge tail of related exceptions

```
[...snip...]
TimeoutError: Timeout waiting for connect response while connecting to xx:xx:xx:xx:xx:xx after 30s, disconnect timed out: False,  after 20.0s

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 960, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1318, in async_device_update
    await self.async_update()
  File "/config/custom_components/basestation/switch.py", line 87, in async_update
    _LOGGER.debug(
    ^^^^^^^
NameError: name '_LOGGER' is not defined
```